### PR TITLE
Make unit test more robust

### DIFF
--- a/tools/unittests.py
+++ b/tools/unittests.py
@@ -8,6 +8,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import unittest
 
 import dbconf
@@ -112,6 +113,17 @@ class YubikeyTestCase(YubiserveTestCase):
         return data
 
 
+def wait_for_server(testserver=testserver):
+    while True:
+        try:
+            conn = httplib.HTTPConnection(testserver)
+            conn.request('GET', "/")
+            conn.close()
+            return
+        except IOError:
+            time.sleep(0.1)
+
+
 if __name__ == '__main__':
     filename = '/tmp/yubiservetest.sqlite3'
 
@@ -125,6 +137,7 @@ if __name__ == '__main__':
     yubikey = dbconf.Yubikey(filename, verbose=False)
 
     p = subprocess.Popen([ './src/yubiserve.py', '--db', filename ], stderr=open('/dev/null', 'w'))
+    wait_for_server()
 
     suite = unittest.TestLoader().loadTestsFromTestCase(YubikeyTestCase)
     unittest.TextTestRunner().run(suite)

--- a/tools/unittests.py
+++ b/tools/unittests.py
@@ -7,7 +7,6 @@ import httplib
 import os
 import re
 import subprocess
-import sys
 import time
 import unittest
 

--- a/tools/unittests.py
+++ b/tools/unittests.py
@@ -126,6 +126,11 @@ def wait_for_server(testserver=testserver):
 if __name__ == '__main__':
     filename = '/tmp/yubiservetest.sqlite3'
 
+    try:
+        os.unlink(filename)
+    except OSError:
+        pass
+
     # create database
     dbcreate.create_db(filename)
 
@@ -138,10 +143,11 @@ if __name__ == '__main__':
     p = subprocess.Popen([ './src/yubiserve.py', '--db', filename ], stderr=open('/dev/null', 'w'))
     wait_for_server()
 
-    suite = unittest.TestLoader().loadTestsFromTestCase(YubikeyTestCase)
-    unittest.TextTestRunner().run(suite)
+    try:
+        suite = unittest.TestLoader().loadTestsFromTestCase(YubikeyTestCase)
+        unittest.TextTestRunner().run(suite)
+    finally:
+        api.delete('test')
+        os.unlink(filename)
 
-    api.delete('test')
-    os.unlink(filename)
-
-    p.kill()
+        p.kill()


### PR DESCRIPTION
* Avoids a race condition in test startup
* Avoids creating zombie server processes
* Forcibly unlinks an existing temporary database file