### PR TITLE
Port to cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+cryptography<2


### PR DESCRIPTION
Use cryptography instead of pycrypto since pycrypto is no longer
maintained; i.e. it hasn't seen a release since 2013 or a commit to master since 2014.

pycrypto still _works_ but there's at least one buffer overflow that doesn't have a fix in a released version -- https://github.com/dlitz/pycrypto/issues/176 -- though yubikeyedup isn't affected by it.